### PR TITLE
docs: improve AI stack caveats

### DIFF
--- a/data/ai.md
+++ b/data/ai.md
@@ -12,8 +12,9 @@
 - Good balance between flexibility and developer experience
 
 **Caveats**
-- Model costs and latency need active monitoring
-- Retrieval quality depends on chunking and evaluation
+- Model costs can spike quickly with long conversations, so set token budgets and alert on usage early
+- Latency depends on model choice, prompt length, and retrieval calls; stream responses or cache common answers where possible
+- Retrieval quality depends on chunking, embedding refreshes, and evaluation against real user questions
 
 ## Notebook to App
 


### PR DESCRIPTION
## Summary
- expand the Chat Pilot caveats with practical cost controls
- call out latency drivers and mitigation options
- make retrieval quality risks more specific for builders

## Validation
- git diff --check

Fixes #4

Confidence: 82/100 (docs, issue-backed)